### PR TITLE
Migrate backend service code based on CloudSQL/Parse-PartDashboard from gitlab

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,31 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/
+
+# local log files
+logs
+tmp.txt
+
+# local config file
+config-dev.json
+config-dev.yml
+
+# vscode files
+.vscode/
+
+# other local files
+gcloud_excluded/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+logs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,62 @@
-# keep-ahope-gcp
-Backend and service layers built on Google Cloud Platform
+# AHOPE Project on Google App Engine:  Postgresql, Parse-Server, and Parse-dashboard in backend with Google Sign-in for Authentication
+
+This project sets up [Parse-server](https://github.com/ParsePlatform/parse-server) and [Parse-dashboard](https://github.com/parse-community/parse-dashboard) to run 
+[Google App Engine](https://cloud.google.com/appengine) Node.js [standard environment](https://cloud.google.com/appengine/docs/standard/nodejs).  This project is based on the original [Parse sample project](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/master/appengine/parse-server)
+
+## Downloading Files
+
+1. `git clone https://github.com/evandana/keep-ahope-gcp`
+1. `cd keep-ahope-gcp`
+
+## Setup -  Cloud (App Engine) Only
+
+1. Create a project in the [Google Cloud Platform Console](https://console.cloud.google.com/).
+1. [Enable billing](https://console.cloud.google.com/project/_/settings) for your project.
+1. [Create an OAuth2 client](https://console.cloud.google.com/apis/credentials) for your project.  This is done by choosing "Create credentials" then "OAuth client ID" under the Credentials tab.  Select "Web Application" as the Application type.  The name of the client doesn't matter, but be sure to add to "Authorized JavaScript origins" the domain (in the format of scheme://server-address:port-number) where the app will run.  Note the client id that is created.
+1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/).
+1. Create a Cloud SQL instance (Postgresql flavor) in the same project, and note its cloud SQL instance connection name, such as:
+   `ahope-parse-poc:northamerica-northeast1:ahope-poc-db`
+   It is simple concatenation of GCloud project name, region name, and the CloudSQL instance id, separated by colons.
+1. In the Cloud SQL instance, create a database user (also known as a "login role" in Postgresql) and create a database that this user either owns
+   or has all privileges.
+1. In [config.yml](./config.yml) file, configure properties as documented there.
+1. As of now, you also need to add the CloudSQL connection name (see above) to app.standard.yml, under beta_settings.cloud_sql_instances
+
+## Setup - Local
+
+1. Setup a Postgresql server either locally or on another host that the local dev machine can reach by TCP socket.  Cloud SQL uses Postgresql 9.6.  While it is recommended to use the same version when installing locally, it's unlikely for version to matter if you want to use an existing Postgresql server of a version that is close to 9.6.  Collect the hostname and port number.
+2. Same as setting up for cloud, create a database user and a database that this new user owns or can administer.
+3. In [config-dev.yml](./config-dev.yml) file, create/update the following properties:
+    1. DATABASE_URI: "postgres://\<db-user>:\<db-password>@/\<hostname:port>/\<database-name>".
+    1. SERVER_URL: "http://localhost:8080/parse"  
+    Note that all properties in [config.yml](./config.yml) file are inherited, subject to overriding.  
+    
+    If you want to run Parse server locally but using the Cloud SQL in Google Cloud, you can install and run
+    a proxy, which opens and listens on a local TCP port to receive and route Postgresql requests to the Cloud SQL instance.  You should update DATABASE_URI
+    accordingly to reflect the local host name and the port number used by the proxy.  For more details see [Cloud SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy).
+
+## Running locally
+
+1. Follow the "Setup - Local" section above.  Make sure the configuration files are set correctly.
+1. `npm install`
+1. `npm start`
+1. Goto http://localhost:8080/dashboard to access the Parse Dashboard.  URL http://localhost:8080/parse can be used for REST API access.
+1. When logging into dashboard running locally, use ahope-admin/ahope as username/password.  See [server.js](./server.js) where passwords are set for local and cloud environments.
+1. Note that Parse Server, when running locally but behind a corporate firewall, will likely not be able to validate an id token provided by Google Sign-in.
+
+## Client side development
+
+1. See a [sample page](./static/index.html) for how Google Sign-in and Parse Javascript SDK are used.
+1. To access the page locally, go to http://localhost:8080/static/index.html.
+1. Any complex business logic can be implemented as "Cloud Functions", as shown in [Cloud Function](./cloud/main.js), which runs on the server side.
+
+## Deploy to App Engine standard environment
+
+1. Make sure the necessary [environment variables](./config.yml) are set correctly.  See the "Setup - Cloud (App Engine) Only" section above.
+1. `gcloud app deploy app.standard.yaml`
+
+Refer to the [appengine/README.md](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/master/appengine/README.md) file for more instructions on
+running and deploying.
 
 ## UI
 

--- a/app.flexible.yaml
+++ b/app.flexible.yaml
@@ -1,0 +1,17 @@
+# Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START app_yaml]
+runtime: nodejs
+env: flex
+# [END app_yaml]

--- a/app.standard.yaml
+++ b/app.standard.yaml
@@ -18,7 +18,7 @@ instance_class: F2
 
 handlers:
 - url: /.*
-  script: true
+  script: auto
   secure: always
   redirect_http_response_code: 301
   

--- a/app.standard.yaml
+++ b/app.standard.yaml
@@ -1,0 +1,32 @@
+# Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START app_yaml]
+runtime: nodejs8
+# note: the lowest F1 class turns out way too slow...
+instance_class: F2
+
+handlers:
+- url: /.*
+  script: true
+  secure: always
+  redirect_http_response_code: 301
+  
+env_variables:
+  # PORT: 443
+beta_settings:
+  # The connection name of your instance, available by using
+  # 'gcloud beta sql instances describe [INSTANCE_NAME]' or from
+  # the Instance details page in the Google Cloud Platform Console.
+  cloud_sql_instances: keep-ahope:us-east1:ahope-postgres-dev
+# [END app_yaml]

--- a/cloud/main.js
+++ b/cloud/main.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Parse.Cloud.define('hello', function(req, res) {
+  res.success('Hello, world!');
+});

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['app', 'deploy', 'app.standard.yaml']
+timeout: '1600s'

--- a/config-dev.yml
+++ b/config-dev.yml
@@ -1,0 +1,23 @@
+# The config file used only for local development purposes.
+#
+# Reminder: you don't need put everything here; just the top-level properties for which you want to override
+#   the values inherited from config.yml.
+
+# Note: you can run a local proxy to the CloudSQL instance or a local Postgresql server, or even a local Mongo db.
+DATABASE_URI: postgres://postgres:postgres@localhost:5433/ahope
+
+DATABASE_OPTIONS: {}
+# empty it out any database options that the production version of the yml file may contain.
+
+SERVER_URL: http://localhost:8080/parse
+
+ALLOW_CLIENT_CLASS_CREATION: true
+
+DASHBOARD_SETTINGS:
+  # If a different Parse server is used, then uncomment the following section.
+  # apps:
+  #   - serverUrl: https://an_alternative_parse_server/parse
+  users:
+    - user: ahope-admin
+      pass: ahope
+  useEncryptedPasswords: false

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,71 @@
+# The overall Google Cloud Project ID.  This property is mandatory
+# I case the GCP project name is different from the ID, make sure ID is used here.
+PROJECT_ID: keep-ahope
+
+# --------------------------------------------------------------------------------------
+# It is assumed that the CloudSQL instance we use to store data is in the same project
+# and therefore no need to create a service account to access across project.
+# --------------------------------------------------------------------------------------
+
+# CLOUDSQL_REGION identifies the geographical region of the CloudSQL instance.
+# This is selected at the time of instance creation.
+CLOUDSQL_REGION: us-east1
+
+# CLOUDSQL_INSTANCE_ID identifies an instance of Google Cloud SQL, which should be viewable at
+# https://console.cloud.google.com/sql/instances.  The left-most column is the instance id.
+CLOUDSQL_INSTANCE_ID: ahope-postgres-dev
+
+# CLOUDSQL_CONNECTION_NAME:
+# An instance's connection name can be viewed in the Overview tab of the "Instance details" page.
+# It is concatenation of $PROJECT_ID:$CLOUDSQL_REGION:$CLOUDSQL_INSTANCE_ID, separated by colons.
+# If this property is not defined in this yml file, then it will be formed by concatenating the
+# three properties defined above.
+# If this property is defined, then no need to define CLOUDSQL_INSTANCE_ID, and CLOUDSQL_REGION.
+# CLOUDSQL_CONNECTION_NAME: keep-ahope:us-east1:ahope-postgres-dev
+
+# DATABASE_CREDENTIALS is the CloudSQL database user and the password, separated by a colon.
+# This property is mandatory unless DATABASE_URI is defined (which includes it)
+DATABASE_CREDENTIALS: postgres:ki0YfYUzZHOQ5l4v
+
+# DATABASE_NAME is the name of the database inside a CloudSQL instance.  A CloudSQL instance is just an instance
+# of PostgreSQL server, which is capable of hosting multiple databases inside it, and hence a database name
+# is needed to identify the database to use.
+# This property is mandatory unless DATABASE_URI is defined (which includes it)
+DATABASE_NAME: ahope
+
+# DATABASE_URI, when undefined here, is formed as 
+#   postgres://$DATABASE_CREDENTIALS@/cloudsql/$CLOUDSQL_CONNECTION_NAME/$DATABASE_NAME
+# DATABASE_URI: postgres://postgres:ki0YfYUzZHOQ5l4v@/cloudsql/keep-ahope:us-east1:ahope-postgres-dev/ahope
+
+# DATABASE_OPTIONS, leave it undefined for Cloud environment.
+#DATABASE_OPTIONS:
+#  protocol: "socket:"
+#  host: /cloudsql/keep-ahope:us-east1:ahope-postgres-dev:ahope
+#  database: ahope
+
+# If no MASTER_KEY is configured, then a randomly generated one will be used.  This is recommended.
+# MASTER_KEY: ahope-test-app-master-key-keep-it-secret
+
+# Note: FILE_KEY is only needed if we store files.
+# FILE_KEY: <your-file-key>,
+
+# PARSE_MOUNT_PATH: /parse
+
+# SERVER_URL: https://ahope-parse-poc.appspot.com/parse
+
+# Get the OAuth Client ID here:
+# https://console.cloud.google.com/apis/credentials?project=keep-ahope&orgonly=true&supportedpurview=organizationId
+#
+OAUTH_CLIENT_ID: 888227269181-14qpprrki7r8l9b6gaknd9fle8gkas9k.apps.googleusercontent.com
+
+# Whether to allow a client to create classes (custom tables).  Default to false, but can be changed to true during development
+# ALLOW_CLIENT_CLASS_CREATION: false
+
+DASHBOARD_SETTINGS:
+  # If a different Parse server is used, then uncomment the following section.
+  # apps:
+  #   - serverUrl: https://an_alternative_parse_server/parse
+  users:
+    - user: ahope-admin
+      pass: $2y$12$ssWRVAqcxuumoLZGlaCI1O8NRo36II43VRuiiEaqFIqNjttDGaCiG
+  useEncryptedPasswords: true

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "appengine-parse-server",
+  "description": "Parse-server sample for Google App Engine",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache Version 2.0",
+  "author": "Google Inc.",
+  "engines": {
+    "node": "8.x.x"
+  },
+  "dependencies": {
+    "@google-cloud/debug-agent": "^2.6.0",
+    "express": "4.16.2",
+    "js-yaml": "^3.12.0",
+    "nconf": "0.10.0",
+    "parse-dashboard": "^1.2.0",
+    "parse-server": "2.7.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// [START app]
+const express = require('express');
+const nconf = require('nconf');
+const ParseServer = require('parse-server').ParseServer;
+const path = require('path');
+const yml = require('js-yaml');
+const ymlFormatter = { parse: yml.safeLoad, stringify: yml.safeDump };
+
+var projectId, connectionName, databaseName;
+
+if (process.env.NODE_ENV === 'production') {
+  require('@google-cloud/debug-agent').start();
+}
+
+nconf.argv().env()
+  .file('dev-override', {file: 'config-dev.yml', format: ymlFormatter})
+  .file({ file: 'config.yml', format: ymlFormatter });
+
+const app = express();
+
+// Reference: https://parseplatform.org/parse-server/api/master/ParseServerOptions.html
+const serverConfig = {
+  cloud: nconf.get('CLOUD_PATH') || path.join(__dirname, '/cloud/main.js'),
+  // This appId is used to uniquely identify one out of many possible "applications" hosted by one Parse server.
+  // we are only deploying one app.
+  appId: nconf.get('APP_ID') || 'AHOPE-App-in-Parse',
+  // An empty or undefined master key indicates that Parse server and Parse Dashboard are collocated and can use a randomly generated password
+  masterKey: nconf.get('MASTER_KEY') || require('crypto').randomBytes(48).toString('base64'),
+  fileKey: nconf.get('FILE_KEY'),
+  mountPath: nconf.get('PARSE_MOUNT_PATH') || '/parse',
+  auth: { google: true },
+  enableAnonymousUsers: false,
+  allowClientClassCreation: nconf.get('ALLOW_CLIENT_CLASS_CREATION') || false
+}
+
+
+serverConfig.serverURL = nconf.get('SERVER_URL') || 'https://'.concat(projectId = nconf.get('PROJECT_ID'), '.appspot.com', serverConfig.mountPath),
+
+
+serverConfig.databaseURI = nconf.get('DATABASE_URI');
+
+function getConnectionName()
+{
+  return nconf.get('CLOUDSQL_CONNECTION_NAME') || 
+    [(projectId || nconf.get('PROJECT_ID')), nconf.get('CLOUDSQL_REGION'), nconf.get('CLOUDSQL_INSTANCE_ID')].join(':')
+}
+
+if (!serverConfig.databaseURI) {
+  if (!connectionName) connectionName = getConnectionName();
+  const databaseCredentials = nconf.get('DATABASE_CREDENTIALS');
+  databaseName = nconf.get('DATABASE_NAME');
+  serverConfig.databaseURI = 'postgres://'.concat(databaseCredentials, '@/cloudsql/', connectionName, '/', databaseName);
+}
+
+
+serverConfig.databaseOptions = nconf.get('DATABASE_OPTIONS');
+
+// If DATABASE_OPTIONS is not defined at all, then populate it.
+// If DATABASE_OPTIONS is specifically defined to be empty, then leave it as is - this is useful in local dev mode,
+// where we don't need any database options beyond what is provided in serverConfig.databaseURI.
+if (!serverConfig.databaseOptions) {
+  // In Google Cloud, in order for an App to "locally" access a CloudSQL database, UNIX domain socket has to be used to connect.
+  // Hence the need to provide a databaseOptions.  It appears that if we provide value for .protocol, then we need to provide
+  // .host and .database as well, as their values may not be picked up from serverConfig.databaseURI.
+  //
+  serverConfig.databaseOptions = 
+  {
+    protocol: 'socket:',
+    host: '/cloudsql/'.concat(connectionName || getConnectionName()),
+    database: databaseName || nconf.get('DATABASE_NAME')
+  };
+}
+
+// oauthClientId is to be passed onto the client side to allow user authentication using Google sign-in.
+const oauthClientId = nconf.get('OAUTH_CLIENT_ID');
+
+console.log("OAuth Client ID is: " + oauthClientId);
+console.log("database URI is: " + serverConfig.databaseURI);
+console.log("databaseOptions is: " + JSON.stringify(serverConfig.databaseOptions));
+
+const parseServer = new ParseServer(serverConfig);
+
+// Mount the Parse API server middleware to /parse
+app.use(serverConfig.mountPath || '/parse', parseServer);
+
+const dashboardSettings = nconf.get('DASHBOARD_SETTINGS');
+
+if (dashboardSettings) {
+  if (!dashboardSettings.apps) dashboardSettings.apps = [{}];
+
+  const appSettings = dashboardSettings.apps[0];
+
+  if (!appSettings.serverURL) appSettings.serverURL = serverConfig.serverURL;
+  if (!appSettings.appId) appSettings.appId = serverConfig.appId;
+  if (!appSettings.masterKey) appSettings.masterKey = serverConfig.masterKey;
+  if (!appSettings.appName) appSettings.appName = "AHOPE Administrators Dashboard";
+
+  console.log("Server URL used by dashboard is: " +  appSettings.serverURL);
+
+  dashboardSettings.users.forEach(user => { if (!user.apps) user.apps = [{appId: serverConfig.appId}] } ) ;
+
+  const ParseDashboard = require('parse-dashboard');
+  const dashboard = new ParseDashboard(dashboardSettings,  { allowInsecureHTTP: true });
+  app.use('/dashboard', dashboard); 
+}
+
+app.get('/', (req, res) => {
+  if (dashboardSettings) {
+    res.redirect('/dashboard');
+  } else {
+    res.status(200).send('Hello, world!');
+  }  
+});
+
+app.use('/static', express.static('static'))
+
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => {
+  console.log(`App listening on port ${PORT}`);
+  console.log('Press Ctrl+C to quit.');
+});
+// [END app]

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,113 @@
+<html lang="en">
+  <head>
+    <meta name="google-signin-scope" content="profile email">
+    <meta name="google-signin-client_id" content="35758277434-m0ammk4hoi6l6g8dbjm82q2fk72624i3.apps.googleusercontent.com">
+    <script src="https://apis.google.com/js/platform.js" async defer></script>
+    <script src="https://requirejs.org/docs/release/2.2.0/minified/require.js"></script>
+  </head>
+  <body>
+    <style>
+      .tall {margin-top: 16px;}
+    </style>
+    <div class="g-signin2" data-onsuccess="onSignIn" data-theme="dark"></div>
+    <div class="tall"><input id="clickMe" type="button" value="Do a simple query" onclick="tryQuery();" /></div>    
+    <div class="tall"><input id="clickMe2" type="button" value="write a record" onclick="tryCreate();" /></div>    
+    <div class="tall"><a href="#" onclick="signOut();">Sign out</a></div>
+    <script>
+      var user;
+      var parse;
+      const url = 'https://unpkg.com/parse@1.11.1/dist/parse.js';
+      // the current:
+      // 'https://npmcdn.com/parse/dist/parse.js';
+
+      require([url], function (parse) {
+            parse.initialize("ahope-test-app");
+            parse.serverURL = '/parse';
+            window.parse = parse;
+      });
+
+      function signOut() {
+        var auth2 = gapi.auth2.getAuthInstance();
+        auth2.signOut().then(function () {
+          console.log('User signed out.');
+          // user._logOutWithAll();
+          parse.User.logOut();
+          user = null;
+        });
+      }
+
+      function onSignIn(googleUser) {
+        // Useful data for your client-side scripts:
+        var profile = googleUser.getBasicProfile();
+        console.log("ID: " + profile.getId()); // Don't send this directly to your server!
+        console.log('Full Name: ' + profile.getName());
+        console.log('Given Name: ' + profile.getGivenName());
+        console.log('Family Name: ' + profile.getFamilyName());
+        console.log("Image URL: " + profile.getImageUrl());
+        console.log("Email: " + profile.getEmail());
+
+        // The ID token you need to pass to your backend:
+        var google_id = profile.getId();
+        var id_token = googleUser.getAuthResponse().id_token;
+        console.log("ID Token: " + id_token);
+
+        var authResp = googleUser.getAuthResponse();
+        user = new parse.User();
+        user.setEmail(profile.getEmail());
+        user._linkWith('google', { authData: {'id': google_id, 'id_token': authResp.id_token, 'access_token': authResp.access_token } });
+
+        //alert(parse.Session.isCurrentSessionRevocable() ? "session is revocable" : "session is irrevocable");
+        //parse.User.enableRevocableSession().then(function () {parse.User_upgradeToRevocableSession();});
+
+        user.givenName = profile.getGivenName();
+        user.lastName = profile.getFamilyName();
+        user.fullName = user.givenName.concat(' ', user.lastName);
+      };
+
+      function tryQuery() {
+        var GameScore = parse.Object.extend("GameScore");
+        var query = new parse.Query(GameScore);
+        // in reality, if user hasn't logged in, we shouldn't even do query
+        // but just to demo the rejection based on permission rules.
+        query.equalTo("playerName", user ? user.fullName : "Sean Plott");
+        query.find({
+            success: function(results) {
+                alert("Successfully retrieved " + results.length + " scores, and the last 3 will be displayed.");
+                // Do something with the returned Parse.Object values
+                results.reverse();  // to display the latest rows.
+                for (var i = 0; i < Math.min(3, results.length); i++) {
+                    var object = results[i];
+                    alert(object.id + ' - ' + object.get('playerName') + ': ' + object.get('score'));
+                    }
+            },
+            error: function(error) {
+                alert("Error: " + error.code + " " + error.message);
+            }
+        });
+      }
+
+      function tryCreate() {
+        var GameScore = parse.Object.extend("GameScore");
+        var gameScore = new GameScore();
+
+        gameScore.set("score", Math.floor((Math.random() * 10000) + 1));
+        // shouldn't even try if user is null, but just to demo the permission rules.
+        gameScore.set("playerName", user ? user.fullName : "Derek Cheter");
+        gameScore.set("cheatMode", false);
+
+        gameScore.save().then((gameScore) => {
+            // Execute any logic that should take place after the object is saved.
+            alert('New object created with objectId: ' + gameScore.id);
+          },
+          (error) => {
+            // Execute any logic that should take place if the save fails.
+            // error is a Parse.Error with an error code and message.
+            alert('Failed to create new object, with error code: ' + error.message);
+          }
+        );
+      }
+
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
This is an entire transplant of our code base for running Google AppEngine from the gitlab repository that we have been using.