### PR TITLE
jlu: externalize connection pool size setting.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,23 @@ DATABASE_NAME: ahope
 #  host: /cloudsql/keep-ahope:us-east1:ahope-postgres-dev:ahope
 #  database: ahope
 
+# DATABASE_CONNECTION_POOL_SIZE defines the connection pool size used by Parse Server, which should not exceed
+# what's given in the PostgreSQL section in https://cloud.google.com/sql/docs/quotas#fixed-limits, based on
+# the amount of RAM configured to the SQL instance.  
+#
+# Note the foot note there:
+#
+#    Cloud SQL for PostgreSQL reserves up to six of these connections for internal operations.
+#
+# PostgreSQL reserves a few (by default 3) connections for the superuser. See
+#   https://www.postgresql.org/docs/9.6/runtime-config-connection.html#GUC-SUPERUSER-RESERVED-CONNECTIONS
+#
+# In addition, in the "App Engine Limits" section in https://cloud.google.com/sql/docs/quotas
+# Each App Engine instance running in a standard environment cannot have more than 100 concurrent connections
+# Therefore, make sure this limit is observed as well.
+#
+DATABASE_CONNECTION_POOL_SIZE: 16
+
 # APP_ID: applicationId, a unique id identifying a Parse application on a Parse server.
 # For our purposes, it is arbitrary as long as the front end uses the same applicationId when calling Parse.initialize().
 APP_ID: AHOPEPARSESERVER

--- a/server.js
+++ b/server.js
@@ -84,8 +84,20 @@ if (!serverConfig.databaseOptions) {
   {
     protocol: 'socket:',
     host: '/cloudsql/'.concat(connectionName || getConnectionName()),
-    database: databaseName || nconf.get('DATABASE_NAME')
+    database: databaseName || nconf.get('DATABASE_NAME'),
+    // idleTimeoutMillis: 60000,
+    application_name: 'ParseServer',  // this shows up in column "application_name" in pg_catalog.pg_stat_activity view.
   };
+}
+
+// Setting poolSize.
+// See https://github.com/vitaly-t/pg-promise/wiki/Connection-Syntax, which also has a link to 
+// the default values: https://github.com/brianc/node-postgres/blob/master/lib/defaults.js
+// The default values listed there seem questionable (perhaps overridden somewhere) as the idle timeout
+// is definitely not 30 seconds by default in my testing.
+if (!serverConfig.databaseOptions.max) {
+  const size = nconf.get('DATABASE_CONNECTION_POOL_SIZE');
+  if (size) serverConfig.databaseOptions.max = size;
 }
 
 // oauthClientId is to be passed onto the client side to allow user authentication using Google sign-in.


### PR DESCRIPTION
This PR will make the SQL connection pool size configurable in our config.yml file, which is necessary as it needs to match the configured PostgreSQL instance's connection limits, to maximize SQL query performance and avoid "too many clients" errors.

The setting has been proven to work, however it remains to be determined if 16 is the optimal value for a db-f1-micro machine type with 0.6G of RAM.