### PR TITLE
First cut to build and integrate the front-end

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -29,3 +29,6 @@ config-dev.yml
 
 # other local files
 gcloud_excluded/
+
+#front end source code doesn't need to be deployed.
+front-end-src/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,14 @@
 steps:
+- name: 'gcr.io/cloud-builders/git'
+  args: ['clone', '--depth', '1', '--branch', 'parse-refactor-effort', 'https://github.com/evandana/keep-ahope', 'front-end-src']
+- name: 'gcr.io/cloud-builders/npm'
+  args: ['install']
+  dir: 'front-end-src'
+- name: 'gcr.io/cloud-builders/npm'
+  args: ['run', 'build']
+  dir: 'front-end-src'
+- name: 'busybox'
+  args: ['mv', '-f', 'front-end-src/build', './front-end']
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['app', 'deploy', 'app.standard.yaml']
 timeout: '1600s'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/git'
-  args: ['clone', '--depth', '1', '--branch', 'parse-refactor-effort', 'https://github.com/evandana/keep-ahope', 'front-end-src']
+  args: ['clone', '--depth', '1', '--branch', 'develop', 'https://github.com/evandana/keep-ahope', 'front-end-src']
 - name: 'gcr.io/cloud-builders/npm'
   args: ['install']
   dir: 'front-end-src'

--- a/server.js
+++ b/server.js
@@ -133,6 +133,7 @@ if (dashboardSettings) {
   app.use('/dashboard', dashboard); 
 }
 
+/*
 app.get('/', (req, res) => {
   if (dashboardSettings) {
     res.redirect('/dashboard');
@@ -142,6 +143,15 @@ app.get('/', (req, res) => {
 });
 
 app.use('/static', express.static('static'))
+
+ */
+
+app.use('/front-end', express.static('front-end'))
+
+app.get('/', (req, res) => {
+  res.redirect('/front-end');
+});
+
 
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {


### PR DESCRIPTION
This PR includes changes needed to:

1. Clone the front-end code in order to build, 
2. Build the React app, and
3. Host the resultant front-end in the same Express.js app server that is hosting the Parse and Parse Dashboard.

### Notes

1. Currently, the cloud build is hardcoded to clone and build the front-end's '_parse-refactor-effort_' branch, which we will either parameterize/externalize or change to a production branch.

1. In theory, the front-end React app can be mounted in any path.  See [this](https://facebook.github.io/create-react-app/docs/deployment#building-for-relative-paths).  However, for some reason doing so would cause image files not to be found.  Therefore, the front-end is mounted at root for the time being.

1. In order for Google login to work, the OAuth2 client used by the front-end must be configured to have the hosting domain (https://keep-ahope.appspot.com) as an authorized origin (so this OAuth2 client can't be used in Javascript code hosted by a malicious server).  Otherwise, the app would load but with the Login page hanging (with a spinning donut).  In order to do so, go [here](https://console.cloud.google.com/apis/credentials?project=keep-ahope&authuser=0), click on the OAuth2 client, and add the domain to "Authorized JavaScript origins".