### PR TITLE
Change when we initialize database schema

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,7 +21,6 @@ const nconf = require('nconf');
 const ParseServer = require('parse-server').ParseServer;
 const path = require('path');
 const yml = require('js-yaml');
-const setParseSchema = require('./parseSchema');
 const ymlFormatter = { parse: yml.safeLoad, stringify: yml.safeDump };
 
 var projectId, connectionName, databaseName;
@@ -120,6 +119,7 @@ app.get('/dummy.js', function (req, res) {
 app.get('/parse/ahopeinit', function (req, res) {
   console.log("Request to initialize has been received.");
   res.type('text/plain').send("Schema initialization will start.");
+  const setParseSchema = require('./parseSchema');
   setParseSchema(serverConfig);
 });
 

--- a/server.js
+++ b/server.js
@@ -110,8 +110,18 @@ console.log("databaseOptions is: " + JSON.stringify(serverConfig.databaseOptions
 const parseServer = new ParseServer(serverConfig);
 
 app.get('/dummy.js', function (req, res) {
-  res.type('application/javascript').send("console.log('hello from the dummy service worker');");
+  res.type('text/javascript').send("console.log('hello from the dummy service worker');");
 })
+
+// Note: this endpoint triggers AHOPE application-specific initialization.
+// The reason why "/parse/ahopeinit" is selected is that in the front-end code, we already
+// allow requests to /parse/* and /dashboard/* to not to be intercepted by the service-worker.
+// If we choose to use "/ahopeinit", then we need to change the front-end code.
+app.get('/parse/ahopeinit', function (req, res) {
+  console.log("Request to initialize has been received.");
+  res.type('text/plain').send("Schema initialization will start.");
+  setParseSchema(serverConfig);
+});
 
 // Mount the Parse API server middleware to /parse
 app.use(serverConfig.mountPath || '/parse', parseServer);
@@ -168,8 +178,6 @@ app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);
   console.log('Press Ctrl+C to quit.');
 });
-
-setParseSchema(serverConfig);
 
 
 // [END app]


### PR DESCRIPTION
jlu: changed timing when we initialize ahope classes schema etc.  Can't initialize each time an instance spins up, so make it initialize only upon a hit on endpoint /parse/ahopeinit.  This is a stopgap measure to alleviate the performance issue.