### PR TITLE
Attempt to fix recent Parse Server 500 error due to its attempt to create a local "logs" directory

### DIFF
--- a/app.standard.yaml
+++ b/app.standard.yaml
@@ -25,6 +25,7 @@ handlers:
 env_variables:
   # PORT: 443
   MK_SALT: "%%mk_salt_value%%"
+  PARSE_SERVER_LOGS_FOLDER: "null"
 beta_settings:
   # The connection name of your instance, available by using
   # 'gcloud beta sql instances describe [INSTANCE_NAME]' or from


### PR DESCRIPTION
Preempt Parse Server's creation of logs directory by setting environment PARSE_SERVER_LOGS_FOLDER to string "null" (can't be null value in javascript but rather string literal "null").  Reference:

[https://github.com/parse-community/parse-server/blob/1c9b77975e4336928cbc93030c985bebcff8e54f/src/defaults.js#L8](https://github.com/parse-community/parse-server/blob/1c9b77975e4336928cbc93030c985bebcff8e54f/src/defaults.js#L8)